### PR TITLE
feat: Tone down pink theme

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -8,7 +8,7 @@ const Header = () => (
   <>
     <style jsx>{`
       .header {
-        background: #f0f;
+        background: #ff4bff;
         padding: 60px 0;
       }
       .heading {

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,16 +26,16 @@ const HomePage = () => (
       }
       a {
         color: inherit;
-        text-decoration-color: #f0f;
+        text-decoration-color: #ff4bff;
       }
       a:hover {
-        color: #f0f;
+        color: #ff4bff;
       }
       pre {
         background: #000;
         background: linear-gradient(0deg, #222, #333);
         border-radius: 3px;
-        color: #f0f;
+        color: #ff4bff;
         padding: 10px 20px;
       }
       code {


### PR DESCRIPTION
Closes #3

I've toned down the pink in the header and I've also changed other references to the old pink (`#fof`).

### The new header

![image](https://user-images.githubusercontent.com/34886045/122757437-f892b600-d2da-11eb-8a21-2726c84e70c7.png)

### Some of the `pre` tags have been affected but they look fine (the contrast is still ok).

![image](https://user-images.githubusercontent.com/34886045/122757738-56bf9900-d2db-11eb-88a5-fcab512dab22.png)
